### PR TITLE
Fix clang.worker.js old logic to the new logic

### DIFF
--- a/static/js/workers/clang.worker.js
+++ b/static/js/workers/clang.worker.js
@@ -518,8 +518,8 @@ class API extends BaseAPI {
     return stillRunning ? app : null;
   }
 
-  async runUserCode({ filename, contents }) {
-    const basename = filename.replace(/\.c$/, '');
+  async runUserCode({ activeTabName, files }) {
+    const { filename, contents } = files.find(file => file.filename === activeTabName);
     const input = `${basename}.cc`;
     const obj = `${basename}.o`;
     const wasm = `${basename}.wasm`;


### PR DESCRIPTION
Ik was vergeten om deze wijziging mee te nemen ook voor clang, namelijk dat we nu alle bestanden naar de worker sturen met daarbij de active tab naam.