### PR TITLE
WIP: Develop

### DIFF
--- a/static/css/include/base.css
+++ b/static/css/include/base.css
@@ -1,4 +1,6 @@
 :root {
+  --color-white: #fff;
+  --color-black: #000;
   --font-size: 16px;
   --navbar-padding: 10px;
   --editor-tab-font-size: 12px;

--- a/static/css/include/button.css
+++ b/static/css/include/button.css
@@ -17,9 +17,9 @@
   -webkit-appearance: none;
   appearance: none;
   padding: 3px 5px;
-  background: #fff;
+  background: var(--color-white);
   border-radius: 4px;
-  border: 1px solid #000;
+  border: 1px solid var(--color-black);
 }
 
 .run-code-btn {

--- a/static/css/include/button.css
+++ b/static/css/include/button.css
@@ -26,14 +26,14 @@
   background: #62c0ff;
 }
 
-.run-code-btn:not([disabled]):active {
+.run-code-btn:active {
   background: #5dabdf;
 }
 
-.clear-term-btn {
+.stop-code-btn {
   background: #f9776a;
 }
 
-.clear-term-btn:not([disabled]):active {
+.stop-code-btn:active {
   background: #e64a3a;
 }

--- a/static/css/include/goldenlayout.css
+++ b/static/css/include/goldenlayout.css
@@ -101,13 +101,17 @@
 
 .lm_header .lm_tabdropdown_list {
   top: 30px;
+  background-color: var(--color-white);
+  border: 1px solid var(--border-color);
 }
 
 .lm_header .lm_tabdropdown_list .lm_tab {
   border-radius: 0;
-  border: 1px solid var(--border-color);
-  background: #fff;
   padding-bottom: 3px;
+  background-color: transparent;
+  border: 0;
+  width: 100%;
+  text-align: right;
 }
 
 .lm_header .lm_tabdropdown_list .lm_tab:hover {
@@ -116,6 +120,11 @@
 
 .lm_header .lm_tabdropdown_list .lm_tab + .lm_tab {
   margin-top: -1px;
+  border-top: 1px solid var(--border-color);
+}
+
+.lm_header .lm_tabdropdown_list .lm_tab .lm_title {
+  width: auto;
 }
 
 /* dark mode overrides */

--- a/static/css/include/goldenlayout.css
+++ b/static/css/include/goldenlayout.css
@@ -1,5 +1,5 @@
 .lm_goldenlayout {
-  background: #fff;
+  background: var(--color-white);
 }
 
 .lm_goldenlayout,
@@ -51,7 +51,7 @@
 
 .lm_splitter {
   opacity: 1;
-  background: #fff;
+  background: var(--color-white);
   transition: background 200ms ease;
 }
 
@@ -64,7 +64,7 @@
 }
 
 .lm_splitter.locked:hover {
-  background: #fff;
+  background: var(--color-white);
 }
 
 /* Create two vertical bars as a drag-handler icon */

--- a/static/css/include/modal.css
+++ b/static/css/include/modal.css
@@ -29,7 +29,7 @@
   max-width: 100%;
   width: 750px;
   min-width: 400px;
-  background-color: #fff;
+  background-color: var(--color-white);
   border-radius: 3px;
   opacity: 0;
   transition-timing-function: ease;

--- a/static/css/include/settings-dropdown.css
+++ b/static/css/include/settings-dropdown.css
@@ -27,7 +27,7 @@
 
 .settings-dropdown {
   position: absolute;
-  background: #fff;
+  background: var(--color-white);
   display: none;
   right: 0;
   border: 1px solid var(--border-color);
@@ -65,7 +65,7 @@
 
 .settings-dropdown li:hover {
   background-color: var(--tab-menu--tab-bg-color);
-  color: #000;
+  color: var(--color-black);
   cursor: pointer;
 }
 
@@ -74,7 +74,7 @@
 }
 
 .settings-dropdown li.active {
-  color: #000;
+  color: var(--color-black);
   font-weight: bold;
 }
 

--- a/static/css/include/term.css
+++ b/static/css/include/term.css
@@ -1,7 +1,3 @@
-.xterm .xterm-helper-textarea {
-  visibility: hidden !important;
-}
-
 .terminal-component-container .lm_header button + button {
   margin-left: 5px;
 }

--- a/static/js/layout-components.js
+++ b/static/js/layout-components.js
@@ -164,6 +164,20 @@ function EditorComponent(container, state) {
   });
 }
 
+/**
+ * Hide the cursor inside the terminal component.
+ */
+function hideTermCursor() {
+  term.write('\x1b[?25l');
+}
+
+/**
+ * Show the cursor inside the terminal component.
+ */
+function showTermCursor() {
+  term.write('\x1b[?25h');
+}
+
 let term;
 const fitAddon = new FitAddon.FitAddon();
 function TerminalComponent(container, state) {
@@ -199,7 +213,9 @@ function TerminalComponent(container, state) {
       term.write(line + '\n');
     }
     term.write('\n');
+
     setFontSize(fontSize);
+    hideTermCursor();
   });
 
   container.on('fontSizeChanged', setFontSize);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -418,6 +418,7 @@
       },
       title: filename,
       isClosable: false,
+      reorderEnabled: false,
     }));
   }
 

--- a/static/js/workers/clang.worker.js
+++ b/static/js/workers/clang.worker.js
@@ -443,10 +443,16 @@ class API extends BaseAPI {
       return this.untar(this.sysrootFilename);
     });
 
+    this.ready.then(() => {
+      this.loadModules().then(() => {
+        options.readyCallback();
+      });
+    });
+  }
+
+  async loadModules() {
     this.getModule(this.clangFilename);
     this.getModule(this.lldFilename);
-
-    options.readyCallback();
   }
 
   hostWriteCmd(message) {


### PR DESCRIPTION
Deze PR bevat het volgende:
- maak terminal tekst selecteerbaar ([todo#7107358422](https://3.basecamp.com/3088496/buckets/32433293/todos/7107358422))
- aangepaste breedte voor dropdown menu voor de editor tabs, nu is het altijd o.b.v. de langte tab naam, dit had goldenlayout.min.css standaard gezet naar een width van 100px met een ellipsis. 
- stop knop die zichtbaar komt als de code langer dan 1 seconde draait ([todo#7211518194](https://3.basecamp.com/3088496/buckets/32433293/todos/7211518194))
- in de `clang.worker.js` wordt nu eerst gewacht tot alle modules zijn ingeladen en daarna wordt pas de `readyCallback` aangeroepen