### PR TITLE
✨ stdin ✨

### DIFF
--- a/static/js/layout-components.js
+++ b/static/js/layout-components.js
@@ -40,6 +40,8 @@ function runCode(clearTerm = false) {
   if ($('#run-code').prop('disabled')) {
     return;
   } else if (window._workerApi.isRunningCode) {
+    hideTermCursor();
+    term.write('\nProcess terminated\n');
     return window._workerApi.terminate();
   }
 

--- a/static/js/worker-api.js
+++ b/static/js/worker-api.js
@@ -27,13 +27,11 @@ class WorkerAPI {
     this.port = channel.port1;
     this.port.onmessage = this.onmessage.bind(this);
 
-    // this.sharedMem = new WebAssembly.Memory({
-    //   initial: 1,
-    //   maximum: 80,
-    //   shared: true,
-    // });
-
-    this.sharedMem = new SharedArrayBuffer(80); // Specify your desired buffer size here
+    this.sharedMem = new WebAssembly.Memory({
+      initial: 1,
+      maximum: 80,
+      shared: true,
+    });
 
     const remotePort = channel.port2;
     this.worker.postMessage({


### PR DESCRIPTION
This PR adds support for stdin for C which uses `WebAssembly.Memory` and thus requires two headers to be set: 

```
Cross-Origin-Opener-Policy: same-origin
Cross-Origin-Embedder-Policy: require-corp
```

Whenever these two headers are absent, the website stil works normally. However, using stdin will result into errors. It's up to the server to serve the corresponding HTML file with these server response headers.