### PR TITLE
IDE improvements

### DIFF
--- a/static/css/include/button.css
+++ b/static/css/include/button.css
@@ -30,6 +30,22 @@
   background: #62c0ff;
 }
 
+/* loading spinner */
+.run-code-btn.loading:before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid #606060;
+  border-right-color: transparent;
+  margin-right: 5px;
+  vertical-align: middle;
+  position: relative;
+  top: -1px;
+  animation: spin 1s linear infinite;
+}
+
 .run-code-btn:not([disabled]):active {
   background: #5dabdf;
 }

--- a/static/css/include/button.css
+++ b/static/css/include/button.css
@@ -41,3 +41,7 @@
 .danger-btn:active {
   background: var(--color-error-hover);
 }
+
+.modal .danger-btn {
+  font-weight: bold;
+}

--- a/static/css/include/ide/file-tree.css
+++ b/static/css/include/ide/file-tree.css
@@ -122,6 +122,7 @@
 
 .jstree-anchor input {
   outline: 0;
+  border: 1px dotted var(--color-black) !important;
   height: 20px !important;
   max-width: calc(100% - 30px);
 }

--- a/static/css/main.ide.css
+++ b/static/css/main.ide.css
@@ -4,6 +4,7 @@
 @import 'include/ide/file-tree.css';
 @import 'include/settings-dropdown.css';
 @import 'include/goldenlayout.css';
+@import 'include/spinner.css';
 @import 'include/term.css';
 @import 'include/editor.css';
 @import 'include/modal.css';

--- a/static/css/main.ide.css
+++ b/static/css/main.ide.css
@@ -12,7 +12,7 @@
 /* IDE Overrides */
 
 :root {
-  --file-tree-width: 200px;
+  --file-tree-width: 250px;
   --file-tree-padding: 10px;
 }
 

--- a/static/js/worker-api.js
+++ b/static/js/worker-api.js
@@ -195,16 +195,24 @@ class WorkerAPI {
    */
   onmessage(event) {
     switch (event.data.id) {
+
+      // Ready callback from the worker instance. This will be run after
+      // everything has been initialised and ready to run some code.
       case 'ready':
         this.isReady = true;
         $('.lm_header .button').prop('disabled', false);
         $('#run-code').removeClass('loading');
         break;
 
+      // Write callback from the worker instance. When the worker wants to write
+      // code the terminal, this event will be triggered.
       case 'write':
         term.write(event.data.data);
         break;
 
+      // Stdin callback from the worker instance. When the worker requests user
+      // input, this event will be triggered. The user input will be requested
+      // and sent back to the worker through the usage of shared memory.
       case 'readStdin':
         waitForInput().then((value) => {
           const view = new Uint8Array(this.sharedMem.buffer);
@@ -220,10 +228,15 @@ class WorkerAPI {
         });
         break;
 
+      // Run custom config button callback from the worker instance.
+      // This event will be triggered after a custom config button's command has
+      // been executed.
       case 'runButtonCommandCallback':
         $(event.data.selector).prop('disabled', false);
         break;
 
+      // Run user code callback from the worker instance. This event will be
+      // triggered after excecuting the user's code.
       case 'runUserCodeCallback':
         this.runUserCodeCallback();
         break;

--- a/static/js/worker-api.js
+++ b/static/js/worker-api.js
@@ -76,6 +76,8 @@ class WorkerAPI {
   _createWorker(showTerminateMsg) {
     this.isReady = false;
 
+    $('#run-code').addClass('loading');
+
     if (this.worker) {
       this.terminate(showTerminateMsg);
     }
@@ -196,6 +198,7 @@ class WorkerAPI {
       case 'ready':
         this.isReady = true;
         $('.lm_header .button').prop('disabled', false);
+        $('#run-code').removeClass('loading');
         break;
 
       case 'write':


### PR DESCRIPTION
- Fix bug when a C and Python file are both active in split view and then the user refreshes, which ran into an error.
- Delete files recursively when deleting a folder, including closing it's tab if open.
- Small styling improvements: 
  - use dotted border instead of solid for file-tree inline-edit
  - use bold font for danger button in modals
  - add spinner to the run-button to let the user know it is loading up a worker