### PR TITLE
Adjust styling such that the term is always within viewport

### DIFF
--- a/static/css/include/base.css
+++ b/static/css/include/base.css
@@ -55,6 +55,7 @@ body {
 .layout-outer-container {
   width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 .layout-outer-container {

--- a/static/css/include/goldenlayout.css
+++ b/static/css/include/goldenlayout.css
@@ -5,6 +5,7 @@
 .lm_goldenlayout,
 .lm_goldenlayout > div {
   min-width: 100% !important;
+  height: 100% !important;
 }
 
 .lm_header .lm_tab {


### PR DESCRIPTION
When GoldenLayout is initialized, it creates a new container within the layout-container, which made the container slightly higher than the viewport, because the container gets pushed down by the navbar. Forcing the height of the goldenlayout container to be the parent's height fixes this issue, as goldenlayout doesn't take into account the fact that there is a navbar outside of it's container.

See below for the (fixed) demo:



https://github.com/user-attachments/assets/5cf23809-88a3-45e2-9d07-68474e0da89a


