### PR TITLE
Display alert in exam when user closes tab

### DIFF
--- a/static/js/main.exam.js
+++ b/static/js/main.exam.js
@@ -38,6 +38,14 @@ initApp().then(({ layout, config }) => {
     lockApp();
   }
 
+  // Catch ctrl-w and cmd-w to prevent the user from closing the tab.
+  $(window).on('beforeunload', (e) => {
+    const message = 'Are you sure you want to leave this page?';
+    e.preventDefault();
+    e.returnValue = message;
+    return message;
+  });
+
 }).catch((err) => {
   console.error('Failed to bootstrap exam app:', err);
 


### PR DESCRIPTION
Handles any possible way of closing a tab, either through the shortcuts below or manually clicking other buttons in the browser that trigger the same behavior.
- `ctrl/cmd + w` to close the current tab/page
- `ctrl/cmd + r` to reload the current tab/page