### PR TITLE
Hide wasm stacktrace with errors

### DIFF
--- a/static/js/workers/clang.worker.js
+++ b/static/js/workers/clang.worker.js
@@ -270,7 +270,9 @@ class App {
     try {
       this.exports._start();
     } catch (exn) {
-      let writeStack = true;
+      /* Do NOT write the stacktrace, as this is not useful for students. */
+      let writeStack = false;
+
       if (exn instanceof ProcExit) {
         if (exn.code === RAF_PROC_EXIT_CODE) {
           console.log('Allowing rAF after exit.');


### PR DESCRIPTION
One student got a bit confused about the wasm stacktrace that is being printed during 'special errors' such as a division by zero, see reproducable version below:

<img width="1401" alt="image" src="https://github.com/user-attachments/assets/cec1784d-1e41-458b-8d1c-0e45c55ebbce">

Luckily, the wasm-clang creators allowed this to be hidden at all times simply by changing `writeStack = false` :) This results in the following:

<img width="402" alt="image" src="https://github.com/user-attachments/assets/0cef77e5-a2bd-4a66-9052-c70a2898e0ab">
