### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Report unwanted behavior
+title: ''
+labels: 'bug'
+assignees: ''
+---
+
+**Application**
+
+<!--
+Add an 'x' between the '[ ]' brackets to mark which of the applications your
+problem applies to.
+-->
+
+My problem is regarding:
+
+- [ ] Exam
+- [ ] Embed (iframe)
+- [ ] IDE
+
+**Describe the bug**
+
+<!--
+A clear and concise description of what the bug is.
+-->
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+
+1. ...
+
+**Expected behavior**
+
+<!--
+A clear and concise description of what you expected to happen.
+-->
+
+**Screenshots**
+
+<!--
+If applicable, add screenshots to help explain your problem.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!--
+A clear and concise description of what the problem is.
+-->
+
+**Describe the solution you'd like**
+<!--
+A clear and concise description of what you want to happen.
+-->
+
+**Describe alternatives you've considered**
+<!--
+A clear and concise description of any alternative solutions or features you've considered.
+-->
+
+**Additional context**
+<!--
+Add any other context or screenshots about the feature request here.
+-->


### PR DESCRIPTION
Since we have multiple applications, it is nice to have specific issue templates. This way, issues will be more clear and helps to remind the user to fill in which of the applications (exam, embed or IDE) their problem occurs.