### PR TITLE
Handle printing inside infite loops and terminate worker properly

### DIFF
--- a/static/js/layout-components.js
+++ b/static/js/layout-components.js
@@ -224,6 +224,7 @@ function runCode(fileId = null, clearTerm = false) {
       // Worker API is busy, wait for it to be done.
       return;
     } else if (window._workerApi.isRunningCode) {
+      // Terminate worker in cases of infinite loops.
       return window._workerApi.restart(true);
     }
   }
@@ -645,6 +646,24 @@ function waitForInput() {
   });
 }
 
+/**
+ * If the writing goes wrong, this might be due to an infinite loop
+ * that contains a print statement to the terminal. This results in the
+ * write buffer 'exploding' with data that is queued for printing.
+ * This function clears the write buffer which stops (most of the) printing
+ * immediately.
+ *
+ * Furthermore, this function is called either when the user
+ * pressed the 'stop' button or when the xtermjs component throws the error:
+ *
+ *   'Error: write data discarded, use flow control to avoid losing data'
+ */
+function clearTermWriteBuffer() {
+  if (term) {
+    term._core._writeBuffer._writeBuffer = [];
+  }
+}
+
 let term;
 const fitAddon = new FitAddon.FitAddon();
 function TerminalComponent(container, state) {
@@ -791,7 +810,7 @@ class Layout extends GoldenLayout {
   emitToEditorComponents = (event, data) => {
     window._layout.root.contentItems[0].contentItems[0].contentItems.forEach((contentItem) => {
       this._emit(contentItem, event, data);
-    })
+    });
   }
 
   setTheme = (theme) => {

--- a/static/js/worker-api.js
+++ b/static/js/worker-api.js
@@ -240,7 +240,7 @@ class WorkerAPI {
         try {
           // Only write when the worker is ready. This prevents infinite loops
           // with print statements to continue printing after the worker has
-          // terminatedd after the user has pressed the stop button.
+          // terminated when the user has pressed the stop button.
           if (this.isReady) {
             term.write(event.data.data);
           }

--- a/static/js/worker-api.js
+++ b/static/js/worker-api.js
@@ -77,6 +77,7 @@ class WorkerAPI {
     $('#run-code').prop('disabled', true);
 
     hideTermCursor();
+    clearTermWriteBuffer();
 
     if (showTerminateMsg) {
       term.writeln('\x1b[1;31mProcess terminated\x1b[0m');
@@ -236,7 +237,16 @@ class WorkerAPI {
       // Write callback from the worker instance. When the worker wants to write
       // code the terminal, this event will be triggered.
       case 'write':
-        term.write(event.data.data);
+        try {
+          // Only write when the worker is ready. This prevents infinite loops
+          // with print statements to continue printing after the worker has
+          // terminatedd after the user has pressed the stop button.
+          if (this.isReady) {
+            term.write(event.data.data);
+          }
+        } catch (e) {
+          clearTermWriteBuffer();
+        }
         break;
 
       // Stdin callback from the worker instance. When the worker requests user


### PR DESCRIPTION
In C programs, the user can write the following infite loop that prints 42:

```c
#include <stdio.h>

int main(void)
{
    while (1) {
        printf("42\n");
    }
}
```

This prints extremely fast. So fast, that the xterm.js buffer 'explodes' and throws an error. We already offer the user a "stop" button but this did *only* work when nothing was printed to the screen. When the stop button is pressed, the worker is terminated and the `isReady` is false. Simple wrapping the `term.write()` call with a conditional to the `isReady` does fix the problem immediately. Furthermore, the case when the write buffer is exploding can still occur and is also handled.