### PR TITLE
Only print errors when there is an error

### DIFF
--- a/static/js/main.exam.js
+++ b/static/js/main.exam.js
@@ -67,6 +67,10 @@ function initApp() {
   return new Promise((resolve, reject) => {
     loadConfig()
       .then(async (config) => {
+        if (!config.tabs) {
+          config.tabs = {};
+        }
+
         // Get the programming language based on tabs filename.
         const proglang = getFileExtension(Object.keys(config.tabs)[0]);
 

--- a/static/js/workers/py.worker.js
+++ b/static/js/workers/py.worker.js
@@ -110,9 +110,9 @@ class API extends BaseAPI {
       const activeTab = files.find(file => file.name === activeTabName);
 
       this.hostWriteCmd(`python3 ${activeTab.name}`);
-      const stdout = this.run(activeTab.content, activeTabName);
-      if (stdout) {
-        this.hostWrite(stdout);
+      const error = this.run(activeTab.content, activeTabName);
+      if (error) {
+        this.hostWrite(error);
       }
     } finally {
       if (typeof this.runUserCodeCallback === 'function') {
@@ -140,11 +140,10 @@ class API extends BaseAPI {
       const moduleName = activeTabName.replace('.py', '');
       cmd = cmd.map((line) => line.replace('<filename>', moduleName));
 
-      // Run the command and gather its results.
-      const results = this.run(cmd, activeTabName);
-
-      // Print the reults to the terminal in the UI.
-      this.hostWrite(results);
+      const error = this.run(cmd, activeTabName);
+      if (error) {
+        this.hostWrite(error);
+      }
     } finally {
       this.runButtonCommandCallback(selector);
     }
@@ -216,7 +215,7 @@ class API extends BaseAPI {
    *
    * @param {string} code - The python code to run.
    * @param {string} activeTabName - The filename of the active editor tab.
-   * @returns {string} The output of the python code.
+   * @returns {string|undefined} The error message or undefined.
    */
   run(code, activeTabName) {
     if (!Array.isArray(code)) {


### PR DESCRIPTION
There was a time where, instead of using the result of `this.pyodide.runPython()`, we setup a callback that is getting triggered on every keystroke. Both the `run` and `runButtonCommand` function changed behavior because of this at the time. Initially (before the callback was setup) it would always return either the result of the code, or an error otherwise. Now (after the callback implementation) nothing returns, but only an error when one has been thrown. However, the code still would always trigger a `write(stdout)` when `stdout` was undefined. Simply wrapping this inside an if-statement fixes it, as it should be, but this part has simply been overlooked when implementing the callback at the time.