### PR TITLE
Fix file drag

### DIFF
--- a/static/css/include/ide/file-tree.css
+++ b/static/css/include/ide/file-tree.css
@@ -248,9 +248,10 @@
 
 /* The item that is dragged under the cursor */
 .custom-drag-helper {
+  position: absolute;
   display: inline-block;
   background-color: var(--color-white);
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--border-color);
   padding: 5px 10px;
   border-radius: var(--border-radius);
 }
@@ -377,4 +378,9 @@
 .dark-mode .context-menu-item:hover {
   color: var(--dark-mode-active-tab-fg-color);
   background-color: var(--dark-mode-active-tab-bg-color);
+}
+
+.dark-mode .custom-drag-helper {
+  background-color: var(--dark-mode-bg-lighter);
+  border-color: var(--dark-mode-border-color);
 }

--- a/static/js/file-tree-manager.js
+++ b/static/js/file-tree-manager.js
@@ -25,23 +25,36 @@ setupFileDrop();
 export function setupFileDrop() {
   const $dropzone = $('#file-dropzone');
 
+  // The datatransfer.types will be ['Files'] if the user is dragging a local
+  // filesystem file/folder onto this area.
+  const isLocalFileSystemDrag = (e) =>
+    e.originalEvent.dataTransfer.types.includes('Files');
+
   $dropzone.on('dragover', (e) => {
+    if (!isLocalFileSystemDrag(e)) return;
+
     // This prevents the browser from opening the file.
     e.preventDefault();
     e.stopPropagation();
   });
 
   $dropzone.on('dragenter', (e) => {
+    if (!isLocalFileSystemDrag(e)) return;
+
     $('#file-tree').addClass(DROP_AREA_INDICATOR_CLASS);
     $dropzone.addClass('drag-over');
   });
 
   $dropzone.on('dragleave', (e) => {
+    if (!isLocalFileSystemDrag(e)) return;
+
     $dropzone.removeClass('drag-over');
     $(`.${DROP_AREA_INDICATOR_CLASS}`).removeClass(DROP_AREA_INDICATOR_CLASS);
   });
 
   $dropzone.on('drop', (e) => {
+    if (!isLocalFileSystemDrag(e)) return;
+
     e.preventDefault();
     e.stopPropagation();
     $(`.${DROP_AREA_INDICATOR_CLASS}`).removeClass(DROP_AREA_INDICATOR_CLASS);
@@ -69,7 +82,7 @@ export function setupFileDrop() {
  * @returns {FileSystemEntry|null} The file entry or null if not available.
  */
 function getDataTransferFileEntry(file) {
-  if (file.webkitGetAsEntry)  {
+  if (file.webkitGetAsEntry) {
     return file.webkitGetAsEntry();
   } else if (file.getAsEntry) {
     return file.getAsEntry();
@@ -958,14 +971,14 @@ function _dragStopCallback(targetNode, data) {
   const sourceNode = data.otherNode;
 
   const parentPath = (targetNode.data.isFolder)
-      ? targetNode.key
-      : (targetNode.parent.title.startsWith('root') ? null : targetNode.parent.key);
+    ? targetNode.key
+    : (targetNode.parent.title.startsWith('root') ? null : targetNode.parent.key);
 
   if (data.files.length > 0) { // user dropped one or more filesystem file/folder
     for (var i = 0; i < data.files.length; i++) {
       const item = getDataTransferFileEntry(data.dataTransfer.items[i]);
       if (!item) continue
-      _createFileSystemEntryInVFS(item, '', parentPath).then(() =>  {
+      _createFileSystemEntryInVFS(item, '', parentPath).then(() => {
         createFileTree();
       });
     }

--- a/static/js/file-tree-manager.js
+++ b/static/js/file-tree-manager.js
@@ -48,8 +48,8 @@ export function setupFileDrop() {
   $dropzone.on('dragleave', (e) => {
     if (!isLocalFileSystemDrag(e)) return;
 
-    $dropzone.removeClass('drag-over');
     $(`.${DROP_AREA_INDICATOR_CLASS}`).removeClass(DROP_AREA_INDICATOR_CLASS);
+    $dropzone.removeClass('drag-over');
   });
 
   $dropzone.on('drop', (e) => {
@@ -57,6 +57,7 @@ export function setupFileDrop() {
 
     e.preventDefault();
     e.stopPropagation();
+
     $(`.${DROP_AREA_INDICATOR_CLASS}`).removeClass(DROP_AREA_INDICATOR_CLASS);
     $dropzone.removeClass('drag-over');
 
@@ -617,7 +618,6 @@ export function createFileTree(forceRecreate = false, persistState = true) {
         autoExpandMS: 400,
         dragStart: _dragStartCallback,
         dragEnter: _dragEnterCallback,
-        dragLeave: _dragLeaveCallback,
         dragDrop: _dragStopCallback,
         dragEnd: _dragEndCallback,
       },
@@ -893,14 +893,6 @@ function _dragEnterCallback(targetNode, data) {
 }
 
 /**
- * Callback when the user drags a node away from another node.
- */
-function _dragLeaveCallback() {
-  // Remove the visual drag area indicator.
-  $(`.${DROP_AREA_INDICATOR_CLASS}`).removeClass(DROP_AREA_INDICATOR_CLASS);
-}
-
-/**
  * Callback when the user starts dragging a node in the file tree.
  */
 function _dragStartCallback(node, data) {
@@ -921,6 +913,7 @@ function _dragEndCallback() {
   // Remove the visual drag area indicator.
   $(`.${DROP_AREA_INDICATOR_CLASS}`).removeClass(DROP_AREA_INDICATOR_CLASS);
 
+  $('.custom-drag-helper').remove();
   destroyTooltip('dndDuplicate');
   sortFileTree()
   Terra.v.blockFSPolling = false;

--- a/static/js/fs/vfs.worker.js
+++ b/static/js/fs/vfs.worker.js
@@ -722,7 +722,13 @@ async function findFilesInFolder(folderpath) {
   // Gather all subfile handles.
   const subfiles = [];
   for await (let handle of folderHandle.values()) {
-    if (handle.kind === 'file' && !blacklistedPaths.includes(handle.name)) {
+    // Skip blacklisted paths and .crswap (Chrome's crash recovery swap) files.
+    const isValidFile = (
+      !blacklistedPaths.includes(handle.name)
+      && !handle.name.endsWith('.crswap')
+    );
+
+    if (handle.kind === 'file' && isValidFile) {
       subfiles.push(handle);
     }
   }


### PR DESCRIPTION
The file drag become a bit buggy recently and thus several changes have been made to fix this:
- The custom drag area now only becomes visible when dragging a local filesystem item onto this area and thus won't show when dragging an HTML element onto this. This is done by checking the `event.originalEvent.dataTransfer.types` which is `['Files']` when dragging a local filesystem file and `[ "application/x-fancytree-node", "text/html", "text/plain" ]` when dragging a fancytree node onto this area. The check is simply done on if  the `types` contains `'Files'`.
- I also noticed the custom drag helper (that is the copy of the draggable element—aka file tree node item—that is attached to the cursor while dragging) wasn't visible on Chrome + Safari. The reason was that it didn't had `position: absolute;` however Firefox didn't need this fix weirdly enough.
- I removed the `dragLeave` callback which fixed the weird flickering of the line that indicates where you're about to drop the item.
- There were some stylistic changes that are also in this PR such as double spaces or double intents that have also been removed in here.


**EXTRA:** I noticed another issue when connected to the local filesystem and dragging a file from your own local filesytem onto the filetree it does create a temporary file that ends with `.crswap`. For example: Dragging `main.py` creates `main.py.crswap`. Apparently this is a Chrome-specific thing called Chrome's _crash recovery swap (crswap) _ file. When retrieving the filetree in the `getFileTree()` inside `/src/static/js/fs/vfs.worker.js` there's the `findFilesInFolder` in which certain files are already excluded based on the `blacklistedPaths` variable. I've simply added a check here to also ignore files that end with `.crswap` which won't show this in the filetree anymore.

See the video below that shows the original problem (which has now been fixed). As you see, the crswap does automatically disappears due to the polling we have that reads the LFS  folder again and re-imports the files.

https://github.com/user-attachments/assets/1ee729f2-f108-402c-9bbd-144e1c6de22b

