### PR TITLE
Fix pytest (and other output) not flushing after run.

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -399,7 +399,7 @@ export default class App {
    * @param {string} msg - The message to write.
    */
   termWrite(msg) {
-    this.lastWriteNotTerminated = !msg.endsWith("\n");
+    this.lastWriteNotTerminated = typeof msg !== "string" || !msg.endsWith("\n");
     this.layout.term.write(msg);
   }
 

--- a/static/js/lang-worker.js
+++ b/static/js/lang-worker.js
@@ -110,9 +110,10 @@ export default class LangWorker {
     $('.lm_header .run-user-code-btn, .lm_header .config-btn').prop('disabled', true);
     $('.lm_header .worker-loading-label').show();
 
-    Terra.app.termClearWriteBuffer();
-
+    // Stop button has been clicked, so we clear the
+    // output buffer and show a kill message.
     if (showTerminateMsg) {
+      Terra.app.termClearWriteBuffer();
       Terra.app.termWriteln('\x1b[1;31mProcess terminated\x1b[0m');
     }
 
@@ -330,6 +331,8 @@ export default class LangWorker {
             Terra.app.termWrite(event.data.data);
           }
         } catch (e) {
+          console.log("Caught write error on the terminal - clearing buffer;")
+          console.log(e)
           Terra.app.termClearWriteBuffer();
         }
         break;


### PR DESCRIPTION
Write to terminal from Python now knows how to deal with non-string writes.

Plus a console log is done when a catch kills the terminal output, so it's easier to trace problems with that.