### PR TITLE
Enable run buttons while waiting for Python to boot.

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -251,17 +251,10 @@ export default class App {
   async runCode(options = {}) {
     if (options.clearTerm) this.layout.term.clear();
 
-    if (this.langWorker) {
-      if (!this.langWorker.isReady) {
-        // Worker API is busy, wait for it to be done.
-        return;
-      } else if (this.langWorker.isRunningCode) {
-        // Terminate worker in cases of infinite loops.
-        return this.langWorker.restart(true);
-      }
+    if (this.langWorker?.isRunningCode) {
+      // Terminate worker in cases of infinite loops.
+      return this.langWorker.restart(true);
     }
-
-    // When reaching this part, we actually run the code in the active editor.
 
     // Focus the terminal, such that the user can immediately invoke ctrl+c.
     this.layout.term.focus();
@@ -279,7 +272,7 @@ export default class App {
     const proglang = getFileExtension(filepath);
     this.createLangWorker(proglang);
 
-    // Build args send to the worker's runUserCode function.
+    // Build args to send to the worker's runUserCode function.
     const runUserCodeArgs = [filepath, files];
 
     const runAsConfig = this.getRunAsConfig();
@@ -287,19 +280,17 @@ export default class App {
       runUserCodeArgs.push(runAsConfig);
     }
 
-    // Wait for the worker to be ready before running the code.
-    if (this.langWorker && !this.langWorker.isReady) {
-      const runFileIntervalId = setInterval(() => {
-        if (this.langWorker && this.langWorker.isReady) {
-          this.langWorker.runUserCode(...runUserCodeArgs);
-          this.layout.checkForStopCodeButton();
-          clearInterval(runFileIntervalId);
-        }
-      }, 200);
-    } else if (this.langWorker) {
-      // If the worker is ready, run the code immediately.
+    const run = () => {
       this.langWorker.runUserCode(...runUserCodeArgs);
       this.layout.checkForStopCodeButton();
+    };
+
+    if (this.langWorker && !this.langWorker.isReady) {
+      // Worker is still loading — queue the command to run once it's ready.
+      this.langWorker.pendingCommand = run;
+      $('.lm_header .worker-loading-label').show();
+    } else if (this.langWorker) {
+      run();
     }
   }
 
@@ -348,8 +339,14 @@ export default class App {
     let files = await this.vfs.getAllFiles();
     files = files.concat(this.getHiddenFiles());
 
-    if (this.langWorker && this.langWorker.isReady) {
-      this.langWorker.runButtonCommand(selector, activeTabName, cmd, files);
+    const run = () => this.langWorker.runButtonCommand(selector, activeTabName, cmd, files);
+
+    if (this.langWorker && !this.langWorker.isReady) {
+      // Worker is still loading — queue the command to run once it's ready.
+      this.langWorker.pendingCommand = run;
+      $('.lm_header .worker-loading-label').show();
+    } else if (this.langWorker?.isReady) {
+      run();
     }
   }
 

--- a/static/js/lang-worker.js
+++ b/static/js/lang-worker.js
@@ -50,6 +50,13 @@ export default class LangWorker {
    */
   worker = null;
 
+  /**
+   * A command to execute immediately once the worker signals ready.
+   * Set when a button is clicked while the worker is still (re)loading.
+   * @type {Function|null}
+   */
+  pendingCommand = null;
+
   constructor(proglang) {
     this.proglang = proglang;
     this._createWorker();
@@ -107,9 +114,6 @@ export default class LangWorker {
 
     // Disable the button and wait for the worker to remove the disabled prop
     // once it has been loaded.
-    $('.lm_header .run-user-code-btn, .lm_header .config-btn').prop('disabled', true);
-    $('.lm_header .worker-loading-label').show();
-
     // Stop button has been clicked, so we clear the
     // output buffer and show a kill message.
     if (showTerminateMsg) {
@@ -135,9 +139,6 @@ export default class LangWorker {
     if (this.worker) {
       this.terminate(showTerminateMsg);
     }
-
-    $('.lm_header .run-user-code-btn, .lm_header .config-btn').prop('disabled', true);
-    $('.lm_header .worker-loading-label').show();
 
     console.log(`Spawning new ${this.proglang} worker`);
 
@@ -344,9 +345,15 @@ export default class LangWorker {
       case 'ready':
         this.isReady = true;
         $('.lm_header .worker-loading-label').hide();
-        $('.lm_header .run-user-code-btn').prop('disabled', false);
-        $('.lm_header .clear-term-btn').prop('disabled', false);
-        $('.lm_header .config-btn').prop('disabled', false);
+        if (this.pendingCommand) {
+          const cmd = this.pendingCommand;
+          this.pendingCommand = null;
+          cmd();
+        } else {
+          $('.lm_header .run-user-code-btn').prop('disabled', false);
+          $('.lm_header .clear-term-btn').prop('disabled', false);
+          $('.lm_header .config-btn').prop('disabled', false);
+        }
         break;
 
       // Write callback from the worker instance. When the worker wants to write

--- a/static/js/layout/layout.js
+++ b/static/js/layout/layout.js
@@ -208,9 +208,7 @@ export default class Layout extends eventTargetMixin(GoldenLayout) {
     this.showTermStartupMessage();
     triggerPluginEvent('onLayoutLoaded');
 
-    const workerLoading = Terra.app.langWorker && !Terra.app.langWorker.isReady;
-    const $label = $(`<span class="worker-loading-label" style="${workerLoading ? '' : 'display:none'}">Loading</span>`);
-    $('.terminal-component-container .lm_header').append($label);
+    $('.terminal-component-container .lm_header').append('<span class="worker-loading-label" style="display:none">Loading</span>');
 
     if (Array.isArray(options.autocomplete) && options.autocomplete.every(isObject)) {
       this.emitToTabComponents('setCustomAutocompleter', options.autocomplete);


### PR DESCRIPTION
For a better user flow. Pyodide takes a while to (re)load. The run buttons are now enabled while this happens, disabled when a button is pressed, and the respective action taken right when Pyodide is ready for it.