### PR TITLE
Move lang-worker-client and leave core app functionality in app.

### DIFF
--- a/static/js/app.embed.js
+++ b/static/js/app.embed.js
@@ -53,9 +53,6 @@ export default class EmbedApp extends App {
     // Get the programming language based on the filename.
     const proglang = getFileExtension(queryParams.filename);
 
-    // Initialise the programming language specific worker client.
-    this.createLangWorker(proglang);
-
     // Get the font-size stored in local storage or use fallback value.
     const fontSize = getLocalStorageItem('font-size', BASE_FONT_SIZE);
 

--- a/static/js/app.embed.js
+++ b/static/js/app.embed.js
@@ -7,7 +7,6 @@ import {
   removeIndent,
 } from './helpers/shared.js';
 import Terra from './terra.js';
-import LangWorker from './lang-worker.js';
 import {
   getLocalStorageItem,
   updateLocalStoragePrefix
@@ -54,8 +53,8 @@ export default class EmbedApp extends App {
     // Get the programming language based on the filename.
     const proglang = getFileExtension(queryParams.filename);
 
-    // Initialise the programming language specific worker API.
-    Terra.app.langWorker = new LangWorker(proglang);
+    // Initialise the programming language specific worker client.
+    this.createLangWorker(proglang);
 
     // Get the font-size stored in local storage or use fallback value.
     const fontSize = getLocalStorageItem('font-size', BASE_FONT_SIZE);

--- a/static/js/app.exam.js
+++ b/static/js/app.exam.js
@@ -19,7 +19,6 @@ import {
   getRandNumBetween,
   seconds,
 } from './helpers/shared.js';
-import LangWorker from './lang-worker.js';
 import ExamLayout from './layout/layout.exam.js';
 import {
   setLocalStorageItem,
@@ -72,8 +71,8 @@ export default class ExamApp extends App {
     // Get the programming language based on tabs filename.
     const proglang = getFileExtension(Object.keys(this.config.tabs)[0]);
 
-    // Initialise the programming language specific worker API.
-    this.langWorker = new LangWorker(proglang);
+    // Initialise the programming language specific worker client.
+    this.createLangWorker(proglang);
 
     // Get the font-size stored in local storage or use fallback value.
     const fontSize = getLocalStorageItem('font-size', BASE_FONT_SIZE);
@@ -247,7 +246,7 @@ export default class ExamApp extends App {
     notify('Your code is now locked and cannot be edited anymore.');
 
     // Disable language worker.
-    this.langWorker.terminate();
+    this.terminateLangWorker();
 
     // Make the entire UI read-only.
     this.layout.showLockedState({ prevAutoSaveTime: this.prevAutoSaveTime });

--- a/static/js/app.exam.js
+++ b/static/js/app.exam.js
@@ -71,9 +71,6 @@ export default class ExamApp extends App {
     // Get the programming language based on tabs filename.
     const proglang = getFileExtension(Object.keys(this.config.tabs)[0]);
 
-    // Initialise the programming language specific worker client.
-    this.createLangWorker(proglang);
-
     // Get the font-size stored in local storage or use fallback value.
     const fontSize = getLocalStorageItem('font-size', BASE_FONT_SIZE);
 

--- a/static/js/app.ide.js
+++ b/static/js/app.ide.js
@@ -3,7 +3,6 @@ import IDELayout from './layout/layout.ide.js';
 import { MAX_FILE_SIZE } from './constants.js';
 import { getFileExtension, getRepoInfo, isValidFilename } from './helpers/shared.js';
 import Terra from './terra.js';
-import LangWorker from './lang-worker.js';
 import { getLocalStorageItem } from './local-storage-manager.js';
 import * as fileTreeManager from './file-tree-manager.js';
 import { triggerPluginEvent, getPlugin } from './plugin-manager.js';
@@ -88,8 +87,8 @@ export default class IDEApp extends App {
       setTimeout(() => {
         const editorComponent = this.layout.getActiveEditor();
         const proglang = getFileExtension(editorComponent.getFilename());
-        if (this.langWorker && LangWorker.hasWorker(proglang)) {
-          this.langWorker.restart();
+        if (this.langWorkerClient.hasActiveWorker() && this.langWorkerClient.supports(proglang)) {
+          this.langWorkerClient.restart();
         }
       }, 10);
     });

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -274,8 +274,8 @@ export default class App {
     if (options.clearTerm) this.layout.term.clear();
 
     if (this.langWorkerClient.isRunningCode) {
-      // Terminate worker in cases of infinite loops.
-      return this.langWorkerClient.restart(true);
+      // Act as stop button: abort the running program (e.g. an infinite loop).
+      return this.stopRunningProgramManually();
     }
 
     // Focus the terminal, such that the user can immediately invoke ctrl+c.
@@ -318,7 +318,7 @@ export default class App {
 
   handleControlC(event) {
     if (event.key === 'c' && event.ctrlKey && this.langWorkerClient.isRunningCode) {
-      this.langWorkerClient.restart(true);
+      this.stopRunningProgramManually();
     }
   }
 
@@ -402,7 +402,6 @@ export default class App {
       onRequestStdin: this.termWaitForInput,
       onRunButtonCommandDone: this.onWorkerRunButtonCommandDone,
       onRunEnded: this.onRunEnded,
-      onTerminate: this.onWorkerTerminate,
       onNewOrModifiedFiles: this.onWorkerNewOrModifiedFiles,
       onDeletedFiles: this.onWorkerDeletedFiles,
     };
@@ -479,23 +478,14 @@ export default class App {
   }
 
   /**
-   * Worker handler: the worker has been terminated. Clean up the terminal and,
-   * optionally, print a termination message.
-   *
-   * @param {boolean} [showTerminateMsg] - Print a process-terminated message.
+   * Stop the program the user is currently running: restart the worker so the
+   * next run starts fresh, then clear any pending output and print a termination
+   * notice. The restart triggers onRunEnded, which resets the UI and terminal.
    */
-  onWorkerTerminate(showTerminateMsg) {
-    // Stop button has been clicked, so we clear the output buffer and show a
-    // kill message.
-    if (showTerminateMsg) {
-      this.termClearWriteBuffer();
-      this.termWriteln('\x1b[1;31mProcess terminated\x1b[0m');
-    }
-
-    // Dispose any active user input.
-    this.termDisposeUserInput();
-
-    this.termHideTermCursor();
+  stopRunningProgramManually() {
+    this.langWorkerClient.restart();
+    this.termClearWriteBuffer();
+    this.termWriteln('\x1b[1;31mProcess terminated\x1b[0m');
   }
 
   /**
@@ -570,8 +560,9 @@ export default class App {
   }
 
   /**
-   * Worker handler: the user's code has finished running or was terminated.
-   * Reset the run/stop button and terminal state.
+   * Worker handler: the user's code has finished running or was aborted. Reset
+   * the run/stop button and clean up the terminal. Safe on normal completion
+   * too: there is nothing pending to dispose and the cursor is already hidden.
    */
   onRunEnded() {
     // Only disable the button again if the current tab has a worker, because
@@ -584,6 +575,10 @@ export default class App {
 
     // Print inverted `%` to terminal if last line of output was not terminated by a `\n`.
     this.termForgotNewlinePercent();
+
+    // Dispose any pending stdin prompt left by an aborted run and hide the cursor.
+    this.termDisposeUserInput();
+    this.termHideTermCursor();
 
     // Set focus to the active editor.
     this.getActiveEditor().focus();

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,6 +1,7 @@
-import { getFileExtension, isObject } from './helpers/shared.js'
-import LangWorker from './lang-worker.js';
+import { getFileExtension, isImageExtension, isObject } from './helpers/shared.js'
+import LangWorkerClient from './workers/lang-worker-client.js';
 import Terra from './terra.js';
+import * as fileTreeManager from './file-tree-manager.js';
 import VirtualFileSystem, { FileNotFoundError, FileTooLargeError } from './fs/vfs.js';
 import Layout from './layout/layout.js';
 import { MAX_FILE_SIZE } from './constants.js';
@@ -16,10 +17,10 @@ export default class App {
   layout = null;
 
   /**
-   * Reference to the current programming language worker.
-   * @type {LangWorker}
+   * Reference to the current language worker client.
+   * @type {LangWorkerClient}
    */
-  langWorker = null;
+  langWorkerClient = null;
 
   /**
    * Reference to the Virtual File System (VFS) instance.
@@ -31,6 +32,10 @@ export default class App {
     this._bindThis();
 
     this.vfs = new VirtualFileSystem();
+
+    // The language worker client persists for the lifetime of the app; it only
+    // spawns a worker thread on demand once a supported language is loaded.
+    this.langWorkerClient = new LangWorkerClient(this.getLangWorkerHandlers());
   }
 
   /**
@@ -116,6 +121,14 @@ export default class App {
         }
       });
     });
+
+    // Set the initial run-button state once the layout (and thus its run button)
+    // has been rendered. The editor 'show' events fire before the button exists,
+    // so the active tab's runnability must be re-applied here.
+    this.layout.on('initialised', () => {
+      const activeEditor = this.getActiveEditor();
+      this.updateRunButtonState(activeEditor ? activeEditor.getFilename() : null);
+    });
   }
 
   /**
@@ -155,6 +168,8 @@ export default class App {
       this.createLangWorker(editorComponent.proglang);
     }
 
+    this.updateRunButtonState(editorComponent.getFilename());
+
     await this.setEditorFileContent(editorComponent);
   }
 
@@ -174,6 +189,7 @@ export default class App {
 
   onImageShow(imageComponent) {
     this.terminateLangWorker();
+    this.updateRunButtonState(null);
     this.setImageFileContent(imageComponent);
   }
 
@@ -254,9 +270,9 @@ export default class App {
   async runCode(options = {}) {
     if (options.clearTerm) this.layout.term.clear();
 
-    if (this.langWorker?.isRunningCode) {
+    if (this.langWorkerClient.isRunningCode) {
       // Terminate worker in cases of infinite loops.
-      return this.langWorker.restart(true);
+      return this.langWorkerClient.restart(true);
     }
 
     // Focus the terminal, such that the user can immediately invoke ctrl+c.
@@ -284,22 +300,22 @@ export default class App {
     }
 
     const run = () => {
-      this.langWorker.runUserCode(...runUserCodeArgs);
+      this.langWorkerClient.runUserCode(...runUserCodeArgs);
       this.layout.checkForStopCodeButton();
     };
 
-    if (this.langWorker && !this.langWorker.isReady) {
+    if (this.langWorkerClient.hasActiveWorker() && !this.langWorkerClient.isReady) {
       // Worker is still loading — queue the command to run once it's ready.
-      this.langWorker.pendingCommand = run;
+      this.langWorkerClient.pendingCommand = run;
       $('.lm_header .worker-loading-label').show();
-    } else if (this.langWorker) {
+    } else if (this.langWorkerClient.hasActiveWorker()) {
       run();
     }
   }
 
   handleControlC(event) {
-    if (event.key === 'c' && event.ctrlKey && this.langWorker && this.langWorker.isRunningCode) {
-      this.langWorker.restart(true);
+    if (event.key === 'c' && event.ctrlKey && this.langWorkerClient.isRunningCode) {
+      this.langWorkerClient.restart(true);
     }
   }
 
@@ -342,64 +358,234 @@ export default class App {
     let files = await this.vfs.getAllFiles();
     files = files.concat(this.getHiddenFiles());
 
-    const run = () => this.langWorker.runButtonCommand(selector, activeTabName, cmd, files);
+    const run = () => this.langWorkerClient.runButtonCommand(selector, activeTabName, cmd, files);
 
-    if (this.langWorker && !this.langWorker.isReady) {
+    if (this.langWorkerClient.hasActiveWorker() && !this.langWorkerClient.isReady) {
       // Worker is still loading — queue the command to run once it's ready.
-      this.langWorker.pendingCommand = run;
+      this.langWorkerClient.pendingCommand = run;
       $('.lm_header .worker-loading-label').show();
-    } else if (this.langWorker?.isReady) {
+    } else if (this.langWorkerClient.isReady) {
       run();
     }
   }
 
   /**
-   * Create a new worker instance if none exists already. The existing instance
-   * will be terminated and restarted if necessary.
+   * Create a new language worker client if none exists already. The existing
+   * client will be terminated and restarted if necessary. This is the single
+   * place where a client is constructed, so its handlers are always wired.
    *
    * @param {string} proglang - The proglang to spawn the related worker for.
    */
   createLangWorker(proglang) {
-    // Situation 1: no worker, thus spawn a new one.
-    if (!this.langWorker && LangWorker.hasWorker(proglang)) {
-      this.langWorker = new LangWorker(proglang);
-    } else if (this.langWorker && this.langWorker.proglang !== proglang) {
-      this.langWorker.proglang = proglang;
+    this.langWorkerClient.load(proglang);
 
-      // Situation 2: existing worker but new proglang is invalid.
-      if (!LangWorker.hasWorker(proglang)) {
-        this.terminateLangWorker();
-      } else {
-        // Situation 3: existing worker and new proglang is valid.
-        this.langWorker.restart();
-      }
-    }
-
-    if (!this.langWorker) {
+    if (!this.langWorkerClient.hasActiveWorker()) {
       $('.lm_header .worker-loading-label').hide();
     }
+  }
+
+  /**
+   * Build the app-side reaction callbacks handed to a language worker client.
+   * The client is pure transport and delegates every DOM/VFS/terminal reaction
+   * to these handlers. All methods are already bound to `this` via _bindThis().
+   *
+   * @returns {object} The handlers object.
+   */
+  getLangWorkerHandlers() {
+    return {
+      onReady: this.onWorkerReady,
+      onWrite: this.onWorkerWrite,
+      onWriteError: this.onWorkerWriteError,
+      onRequestStdin: this.termWaitForInput,
+      onRunButtonCommandDone: this.onWorkerRunButtonCommandDone,
+      onRunEnded: this.onRunEnded,
+      onTerminate: this.onWorkerTerminate,
+      onNewOrModifiedFiles: this.onWorkerNewOrModifiedFiles,
+      onDeletedFiles: this.onWorkerDeletedFiles,
+    };
   }
 
   /**
   * Terminate the current language worker if it exists.
    */
   terminateLangWorker() {
-    if (this.langWorker) {
-      this.langWorker.terminate();
-      this.langWorker = null;
+    if (this.langWorkerClient.hasActiveWorker()) {
+      this.langWorkerClient.terminate();
     }
     $('.lm_header .worker-loading-label').hide();
   }
 
   /**
-   * Called when running a program has finished in the language worker.
+   * Enable the run button only when the given file's language has a worker;
+   * disable it otherwise (e.g. plain text, an image, or an Untitled file).
+   * Called whenever the active tab changes.
+   *
+   * @param {string|null} filename - The active tab's filename, or null when the
+   * active tab is not a runnable editor (e.g. an image).
+   */
+  updateRunButtonState(filename) {
+    const canRun = this.langWorkerClient.supports(getFileExtension(filename));
+    $('.lm_header .run-user-code-btn, .lm_header .config-btn').prop('disabled', !canRun);
+  }
+
+  /**
+   * Worker handler: the worker has finished initialising and is ready to run.
+   * Re-enable the worker UI buttons unless a queued command is about to run.
+   *
+   * @param {boolean} hasPendingCommand - Whether a queued command will run now.
+   */
+  onWorkerReady(hasPendingCommand) {
+    $('.lm_header .worker-loading-label').hide();
+
+    if (!hasPendingCommand) {
+      $('.lm_header .run-user-code-btn').prop('disabled', false);
+      $('.lm_header .clear-term-btn').prop('disabled', false);
+      $('.lm_header .config-btn').prop('disabled', false);
+    }
+  }
+
+  /**
+   * Worker handler: write a message produced by the worker to the terminal.
+   *
+   * @param {string} text - The message to write.
+   */
+  onWorkerWrite(text) {
+    try {
+      this.termWrite(text);
+    } catch (e) {
+      console.log("Caught write error on the terminal - clearing buffer;")
+      console.log(e)
+      this.termClearWriteBuffer();
+    }
+  }
+
+  /**
+   * Worker handler: write an error message produced by the worker in red.
+   *
+   * @param {string} text - The error message to write.
+   */
+  onWorkerWriteError(text) {
+    this.termWrite(`\x1b[1;31m${text}\x1b[0m`);
+  }
+
+  /**
+   * Worker handler: a custom config button's command has finished executing.
+   */
+  onWorkerRunButtonCommandDone() {
+    $('.lm_header .run-user-code-btn, .lm_header .config-btn').prop('disabled', false);
+  }
+
+  /**
+   * Worker handler: the worker has been terminated. Clean up the terminal and,
+   * optionally, print a termination message.
+   *
+   * @param {boolean} [showTerminateMsg] - Print a process-terminated message.
+   */
+  onWorkerTerminate(showTerminateMsg) {
+    // Stop button has been clicked, so we clear the output buffer and show a
+    // kill message.
+    if (showTerminateMsg) {
+      this.termClearWriteBuffer();
+      this.termWriteln('\x1b[1;31mProcess terminated\x1b[0m');
+    }
+
+    // Dispose any active user input.
+    this.termDisposeUserInput();
+
+    this.termHideTermCursor();
+  }
+
+  /**
+   * Worker handler: files were created or modified in the worker's internal
+   * filesystem during execution. Reflect the changes in the VFS, open tabs and
+   * the file tree.
+   *
+   * @async
+   * @param {array} newOrModifiedFiles - List of file objects.
+   */
+  async onWorkerNewOrModifiedFiles(newOrModifiedFiles) {
+    if (!Array.isArray(newOrModifiedFiles)) {
+      return;
+    }
+
+    for (const file of newOrModifiedFiles) {
+      // Check if the file already exists in the VFS.
+      if ((await this.vfs.pathExists(file.path))) {
+        // If the file already exists, update its content.
+        await this.vfs.updateFile(file.path, file.content);
+
+        // Check if there's an open tab for this file.
+        const tabComponent = this.getTabComponents().find((component) => {
+          const path = component.getPath();
+          return path == file.path;
+        });
+
+        // If so, update its content.
+        if (tabComponent) {
+          tabComponent.setContent(file.content);
+        }
+      } else {
+        // Otherwise, create a new file in the VFS.
+        await this.vfs.createFile(
+          file.path,
+          file.content,
+        );
+
+        // Automatically open new image files in a tab.
+        if (isImageExtension(file.path)) {
+          this.layout.addFileTab(file.path);
+        }
+      }
+
+      // Recreate the file tree.
+      await fileTreeManager.createFileTree();
+    }
+  }
+
+  /**
+   * Worker handler: files were deleted from the worker's internal filesystem
+   * during execution. Remove them from the VFS and close any open tabs.
+   *
+   * @async
+   * @param {string[]} deletedPaths - List of file paths that were deleted.
+   */
+  async onWorkerDeletedFiles(deletedPaths) {
+    if (!Array.isArray(deletedPaths)) {
+      return;
+    }
+
+    for (const path of deletedPaths) {
+      await this.vfs.deleteFile(path, false);
+
+      const tabComponent = this.getTabComponents().find(
+        (component) => component.getPath() === path
+      );
+      if (tabComponent) {
+        tabComponent.close();
+      }
+    }
+  }
+
+  /**
+   * Worker handler: the user's code has finished running or was terminated.
+   * Reset the run/stop button and terminal state.
    */
   onRunEnded() {
+    // Only disable the button again if the current tab has a worker, because
+    // users can still run code through the contextmenu in the file-tree in the
+    // IDE app.
+    const activeEditor = this.getActiveEditor();
+    const disableRunBtn =
+      !activeEditor ||
+      !this.langWorkerClient.supports(getFileExtension(activeEditor.getFilename()));
+
     // Print inverted `%` to terminal if last line of output was not terminated by a `\n`.
     this.termForgotNewlinePercent();
 
     // Set focus to the active editor.
     this.getActiveEditor().focus();
+
+    this.layout.onRunEnded({ disableRunBtn });
   }
 
   /***** Terminal Management ********************************************/

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -122,12 +122,15 @@ export default class App {
       });
     });
 
-    // Set the initial run-button state once the layout (and thus its run button)
-    // has been rendered. The editor 'show' events fire before the button exists,
-    // so the active tab's runnability must be re-applied here.
+    // Once the layout (and thus its run button) has rendered, spawn the worker
+    // for the initially active tab's language and set the run button to match.
+    // The editor 'show' events fire before the run button exists, so this has to
+    // be (re)applied here rather than relying on those events alone.
     this.layout.on('initialised', () => {
       const activeEditor = this.getActiveEditor();
-      this.updateRunButtonState(activeEditor ? activeEditor.getFilename() : null);
+      const filename = activeEditor ? activeEditor.getFilename() : null;
+      this.createLangWorker(getFileExtension(filename));
+      this.updateRunButtonState(filename);
     });
   }
 

--- a/static/js/app.lab.js
+++ b/static/js/app.lab.js
@@ -10,7 +10,6 @@ import {
   loadStoredConfig,
 } from './app.lab.config.js';
 import { getFileExtension } from './helpers/shared.js';
-import LangWorker from './lang-worker.js';
 import LabLayout from './layout/layout.lab.js';
 import { loadReadme } from './app.lab.readme.js';
 import { getLocalStorageItem } from './local-storage-manager.js';
@@ -85,8 +84,8 @@ export default class LabApp extends App {
     // Get the programming language based on the first filename.
     const proglang = getFileExtension(config.files[0]);
 
-    // Initialise the programming language specific worker API.
-    this.langWorker = new LangWorker(proglang);
+    // Initialise the programming language specific worker client.
+    this.createLangWorker(proglang);
 
     // Get the font-size stored in local storage or use fallback value.
     const fontSize = getLocalStorageItem('font-size', BASE_FONT_SIZE);

--- a/static/js/app.lab.js
+++ b/static/js/app.lab.js
@@ -84,9 +84,6 @@ export default class LabApp extends App {
     // Get the programming language based on the first filename.
     const proglang = getFileExtension(config.files[0]);
 
-    // Initialise the programming language specific worker client.
-    this.createLangWorker(proglang);
-
     // Get the font-size stored in local storage or use fallback value.
     const fontSize = getLocalStorageItem('font-size', BASE_FONT_SIZE);
 

--- a/static/js/file-tree-manager.js
+++ b/static/js/file-tree-manager.js
@@ -2,7 +2,6 @@ import { DROP_AREA_INDICATOR_CLASS } from './ide/constants.js';
 import { getFileExtension, getPartsFromPath, isValidFilename } from './helpers/shared.js'
 import { createModal, hideModal, showModal } from './modal.js'
 import Terra from './terra.js'
-import LangWorker from './lang-worker.js';
 import EditorComponent from './layout/editor.component.js';
 import { createTooltip, destroyTooltip } from './tooltip-manager.js';
 import * as LFS from './fs/lfs.js';
@@ -491,7 +490,7 @@ function _createContextMenuItems($trigger, event) {
       };
     }
 
-    if (LangWorker.hasWorker(getFileExtension(node.title))) {
+    if (Terra.app.langWorkerClient.supports(getFileExtension(node.title))) {
       menu.run = {
         name: 'Run',
         callback: () => {

--- a/static/js/layout/layout.js
+++ b/static/js/layout/layout.js
@@ -216,7 +216,7 @@ export default class Layout extends eventTargetMixin(GoldenLayout) {
     this.showTermStartupMessage();
     triggerPluginEvent('onLayoutLoaded');
 
-    $('.terminal-component-container .lm_header').append('<span class="worker-loading-label" style="display:none">Loading</span>');
+    $('.terminal-component-container .lm_header').append('<span class="worker-loading-label" style="display:none">Waiting for runtime to fully load, just a sec...</span>');
 
     if (Array.isArray(options.autocomplete) && options.autocomplete.every(isObject)) {
       this.emitToTabComponents('setCustomAutocompleter', options.autocomplete);
@@ -575,7 +575,10 @@ export default class Layout extends eventTargetMixin(GoldenLayout) {
    */
   getRunCodeButtonHtml() {
     const runCodeShortcut = isMac() ? '&#8984;+Enter' : 'Ctrl+Enter';
-    return `<button id="run-code" class="button primary-btn run-user-code-btn">Run (${runCodeShortcut})</button>`;
+    // Rendered disabled by default; enabled once a supported language's worker
+    // is ready (or when switching to a runnable tab). Prevents the button from
+    // being clickable for a non-runnable initial tab such as an Untitled file.
+    return `<button id="run-code" class="button primary-btn run-user-code-btn" disabled>Run (${runCodeShortcut})</button>`;
   };
 
   /**
@@ -706,18 +709,39 @@ export default class Layout extends eventTargetMixin(GoldenLayout) {
   }
 
   /**
-   * Change the run-code button to a stop-code button if after 1 second the code
-   * has not finished running (potentially infinite loop scenario).
+   * Change the run-code button to a stop-code button if the code
+   * does not finish immediately (potentially infinite loop scenario).
    */
   checkForStopCodeButton() {
-    Terra.v.showStopCodeButtonTimeoutId = setTimeout(() => {
+    this.showStopCodeButtonTimeoutId = setTimeout(() => {
       const $button = $('#run-code');
       const newText = $button.text().replace('Run', 'Stop');
       $button.text(newText)
         .prop('disabled', false)
         .removeClass('primary-btn')
         .addClass('danger-btn');
-    }, seconds(1));
+    }, seconds(0.2));
+  }
+
+  /**
+   * Change the stop-code button back to a run-code button.
+   */
+  onRunEnded({ disableRunBtn }) {
+    const $button = $('#run-code');
+    const newText = $button.text().replace('Stop', 'Run');
+    $button.text(newText)
+      .prop('disabled', disableRunBtn)
+      .addClass('primary-btn')
+      .removeClass('danger-btn');
+
+    if (!disableRunBtn) {
+      $('.lm_header .config-btn').prop('disabled', false);
+    }
+
+    if (this.showStopCodeButtonTimeoutId) {
+      clearTimeout(this.showStopCodeButtonTimeoutId);
+      this.showStopCodeButtonTimeoutId = null;
+    }
   }
 
   /**

--- a/static/js/workers/lang-worker-client.js
+++ b/static/js/workers/lang-worker-client.js
@@ -16,16 +16,10 @@ const supportedLangs = ['c', 'py'];
  */
 export default class LangWorkerClient {
   /**
-   * The current programming language that is being used.
+   * The programming language the active worker runs, or null when idle.
    * @type {string}
    */
-  _proglang = null;
-
-  /**
-   * The previous programming language that was used.
-   * @type {string}
-   */
-  _prevProglang = null;
+  proglang = null;
 
   /**
    * Contains a shared memory object when enabled.
@@ -105,20 +99,19 @@ export default class LangWorkerClient {
   load(proglang) {
     // Unsupported language: make sure no worker keeps running.
     if (!this.supports(proglang)) {
-      if (this.worker) {
-        this.terminate();
-      }
+      this.terminate();
       return;
     }
 
+    // Switching languages: tear down the current worker first, while
+    // this.proglang still names it (so terminate() logs the right one).
+    if (this.worker && this.proglang !== proglang) {
+      this.terminate();
+    }
+
     if (!this.worker) {
-      // No worker yet: spawn one.
       this.proglang = proglang;
       this._createWorker();
-    } else if (this.proglang !== proglang) {
-      // Worker running for a different language: restart with the new one.
-      this.proglang = proglang;
-      this.restart();
     }
   }
 
@@ -139,15 +132,6 @@ export default class LangWorkerClient {
     }
   }
 
-  set proglang(newLang) {
-    this._prevProglang = this.proglang;
-    this._proglang = newLang;
-  }
-
-  get proglang() {
-    return this._proglang;
-  }
-
   /**
    * Terminate the existing worker process and delegate the terminal/UI cleanup
    * (cursor, user input, terminate message) to the app.
@@ -161,7 +145,7 @@ export default class LangWorkerClient {
       return;
     }
 
-    console.log(`Terminating existing ${this._prevProglang || this.proglang} worker`);
+    console.log(`Terminating existing ${this.proglang} worker`);
 
     this.isRunningCode = false;
     this.isReady = false;
@@ -172,21 +156,15 @@ export default class LangWorkerClient {
   }
 
   /**
-   * Creates a new worker process and terminates the existing worker if needed.
-   *
-   * @param {boolean} [showTerminateMsg] - Print a message in the terminal
-   * indicating the current worker process has been terminated.
+   * Spawn a new worker process for the current proglang. Callers are responsible
+   * for terminating any existing worker first (see load() and restart()).
    */
-  _createWorker(showTerminateMsg) {
+  _createWorker() {
     this.isReady = false;
-
-    if (this.worker) {
-      this.terminate(showTerminateMsg);
-    }
 
     console.log(`Spawning new ${this.proglang} worker`);
 
-    this.worker = new Worker(this.getWorkerPath(this._proglang), { type: 'module' });
+    this.worker = new Worker(this.getWorkerPath(this.proglang), { type: 'module' });
     const channel = new MessageChannel();
     this.port = channel.port1;
     this.port.onmessage = this.onmessage.bind(this);
@@ -267,7 +245,8 @@ export default class LangWorkerClient {
    * indicating the current worker process has been terminated.
    */
   restart(showTerminateMsg) {
-    this._createWorker(showTerminateMsg);
+    this.terminate(showTerminateMsg);
+    this._createWorker();
   }
 
   /**

--- a/static/js/workers/lang-worker-client.js
+++ b/static/js/workers/lang-worker-client.js
@@ -1,8 +1,3 @@
-import { getFileExtension, isImageExtension } from './helpers/shared.js';
-import Terra from './terra.js';
-import * as fileTreeManager from './file-tree-manager.js';
-
-
 /**
  * List of supported programming languages that have a corresponding worker.
  * @type {string[]}
@@ -11,9 +6,15 @@ const supportedLangs = ['c', 'py'];
 
 
 /**
- * Bridge class between the main app and the currently loaded language worker.
+ * Main-thread client that fronts a language worker.
+ *
+ * This class is a pure transport layer: it owns the `Worker` instance and its
+ * shared memory, posts commands to it, routes incoming messages, and manages the
+ * worker lifecycle (spawn/terminate/restart). It has no knowledge of the DOM, the
+ * app, or the VFS — all UI and app-side reactions are delegated to the handlers
+ * object passed to the constructor.
  */
-export default class LangWorker {
+export default class LangWorkerClient {
   /**
    * The current programming language that is being used.
    * @type {string}
@@ -57,19 +58,68 @@ export default class LangWorker {
    */
   pendingCommand = null;
 
-  constructor(proglang) {
-    this.proglang = proglang;
-    this._createWorker();
+  /**
+   * App-side reaction callbacks. See App.getLangWorkerHandlers() for the shape.
+   * @type {object}
+   */
+  handlers = null;
+
+  /**
+   * The client is created once and persists for the lifetime of the app. It does
+   * not spawn a worker until load() is called for a supported language.
+   *
+   * @param {object} handlers - App-side reaction callbacks. Required keys:
+   * onReady, onWrite, onWriteError, onRequestStdin, onRunButtonCommandDone,
+   * onRunEnded, onTerminate, onNewOrModifiedFiles, onDeletedFiles.
+   */
+  constructor(handlers) {
+    this.handlers = handlers;
   }
 
   /**
    * Check whether a given proglang has a corresponding worker implementation.
    *
    * @param {string} proglang - The proglang to check for.
-   * @returns {boolean} True if proglang is valid, false otherwise.
+   * @returns {boolean} True if proglang is supported, false otherwise.
    */
-  static hasWorker(proglang) {
+  supports(proglang) {
     return supportedLangs.some((lang) => proglang === lang);
+  }
+
+  /**
+   * Whether a worker thread is currently running.
+   *
+   * @returns {boolean} True if a worker is active, false otherwise.
+   */
+  hasActiveWorker() {
+    return !!this.worker;
+  }
+
+  /**
+   * Spawn, switch, or tear down the worker thread for a given language. This is
+   * the single entry point the app uses to keep the worker in sync with the
+   * active programming language.
+   *
+   * @param {string} proglang - The programming language to load a worker for.
+   */
+  load(proglang) {
+    // Unsupported language: make sure no worker keeps running.
+    if (!this.supports(proglang)) {
+      if (this.worker) {
+        this.terminate();
+      }
+      return;
+    }
+
+    if (!this.worker) {
+      // No worker yet: spawn one.
+      this.proglang = proglang;
+      this._createWorker();
+    } else if (this.proglang !== proglang) {
+      // Worker running for a different language: restart with the new one.
+      this.proglang = proglang;
+      this.restart();
+    }
   }
 
   /**
@@ -99,32 +149,26 @@ export default class LangWorker {
   }
 
   /**
-   * Terminate the existing worker process, hides term cursor and disposes any
-   * active user input that is active.
+   * Terminate the existing worker process and delegate the terminal/UI cleanup
+   * (cursor, user input, terminate message) to the app.
    *
    * @param {boolean} [showTerminateMsg] - Print a message in the terminal
    * indicating the current worker process has been terminated.
    */
   terminate(showTerminateMsg) {
+    // Safe to call when idle: nothing to tear down without an active worker.
+    if (!this.worker) {
+      return;
+    }
+
     console.log(`Terminating existing ${this._prevProglang || this.proglang} worker`);
 
     this.isRunningCode = false;
+    this.isReady = false;
     this.worker.terminate();
-    this.runUserCodeCallback();
-
-    // Disable the button and wait for the worker to remove the disabled prop
-    // once it has been loaded.
-    // Stop button has been clicked, so we clear the
-    // output buffer and show a kill message.
-    if (showTerminateMsg) {
-      Terra.app.termClearWriteBuffer();
-      Terra.app.termWriteln('\x1b[1;31mProcess terminated\x1b[0m');
-    }
-
-    // Dispose any active user input.
-    Terra.app.termDisposeUserInput();
-
-    Terra.app.termHideTermCursor();
+    this.worker = null;
+    this.handlers.onRunEnded();
+    this.handlers.onTerminate(showTerminateMsg);
   }
 
   /**
@@ -227,179 +271,74 @@ export default class LangWorker {
   }
 
   /**
-   * Callback function for when the user code has finished running or has been
-   * terminated by the user.
+   * Provide the user's stdin input to the worker by writing it into shared
+   * memory and notifying the (blocked) worker thread.
+   *
+   * @param {string} value - The user's input.
    */
-  runUserCodeCallback() {
-    this.isRunningCode = false;
-
-    // Only disable the button again if the current tab has a worker,
-    // because users can still run code through the contextmenu in the
-    // file-tree in the IDE app.
-    const activeEditor = Terra.app.getActiveEditor();
-    let disableRunBtn =
-      !activeEditor ||
-      !this.constructor.hasWorker(getFileExtension(activeEditor.getFilename()));
-
-    // Callback to main app.
-    Terra.app.onRunEnded();
-
-    // Change the stop-code button back to a run-code button.
-    const $button = $('#run-code');
-    const newText = $button.text().replace('Stop', 'Run');
-    $button.text(newText)
-      .prop('disabled', disableRunBtn)
-      .addClass('primary-btn')
-      .removeClass('danger-btn');
-
-    if (!disableRunBtn) {
-      $('.lm_header .config-btn').prop('disabled', false);
+  provideStdin(value) {
+    const view = new Uint8Array(this.sharedMem.buffer);
+    for (let i = 0; i < value.length; i++) {
+      // To the shared memory.
+      view[i] = value.charCodeAt(i);
     }
 
-    if (Terra.v.showStopCodeButtonTimeoutId) {
-      clearTimeout(Terra.v.showStopCodeButtonTimeoutId);
-      Terra.v.showStopCodeButtonTimeoutId = null;
-    }
+    // Set the last byte to the null terminator.
+    view[value.length] = 0;
+
+    Atomics.notify(new Int32Array(this.sharedMem.buffer), 0);
   }
 
   /**
-   * Called from within the worker when files have been added or modified in the
-   * worker's internal filesystem during execution of the program.
+   * Message event handler for the worker. Updates client state and delegates
+   * every app/UI reaction to the handlers object.
    *
-   * @async
-   * @param {array} newOrModifiedFiles - List of file objects.
-   */
-  async newOrModifiedFilesCallback(newOrModifiedFiles) {
-    if (!Array.isArray(newOrModifiedFiles)) {
-      return;
-    }
-
-    for (const file of newOrModifiedFiles) {
-      // Check if the file already exists in the VFS.
-      if ((await Terra.app.vfs.pathExists(file.path))) {
-        // If the file already exists, update its content.
-        await Terra.app.vfs.updateFile(file.path, file.content);
-
-        // Check if there's an open tab for this file.
-        const tabComponent = Terra.app.getTabComponents().find((component) => {
-          const path = component.getPath();
-          return path == file.path;
-        });
-
-        // If so, update its content.
-        if (tabComponent) {
-          tabComponent.setContent(file.content);
-        }
-      } else {
-        // Otherwise, create a new file in the VFS.
-        await Terra.app.vfs.createFile(
-          file.path,
-          file.content,
-        );
-
-        // Automatically open new image files in a tab.
-        if (isImageExtension(file.path)) {
-          Terra.app.layout.addFileTab(file.path);
-        }
-      }
-
-      // Recreate the file tree.
-      await fileTreeManager.createFileTree();
-    }
-  }
-
-  /**
-   * Called from within the worker when files have been deleted from the
-   * worker's internal filesystem during execution of the program.
-   *
-   * @async
-   * @param {string[]} deletedPaths - List of file paths that were deleted.
-   */
-  async deletedFilesCallback(deletedPaths) {
-    if (!Array.isArray(deletedPaths)) {
-      return;
-    }
-
-    for (const path of deletedPaths) {
-      await Terra.app.vfs.deleteFile(path, false);
-
-      const tabComponent = Terra.app.getTabComponents().find(
-        (component) => component.getPath() === path
-      );
-      if (tabComponent) {
-        tabComponent.close();
-      }
-    }
-  }
-
-  /**
-   * Message event handler for the worker.
-   *
-   * @param {object} event - Event object coming from the UI.
+   * @param {object} event - Event object coming from the worker.
    */
   onmessage(event) {
     switch (event.data.id) {
 
       // Ready callback from the worker instance. This will be run after
       // everything has been initialised and ready to run some code.
-      case 'ready':
+      case 'ready': {
         this.isReady = true;
-        $('.lm_header .worker-loading-label').hide();
-        if (this.pendingCommand) {
+        const hasPendingCommand = !!this.pendingCommand;
+        this.handlers.onReady(hasPendingCommand);
+        if (hasPendingCommand) {
           const cmd = this.pendingCommand;
           this.pendingCommand = null;
           cmd();
-        } else {
-          $('.lm_header .run-user-code-btn').prop('disabled', false);
-          $('.lm_header .clear-term-btn').prop('disabled', false);
-          $('.lm_header .config-btn').prop('disabled', false);
         }
         break;
+      }
 
       // Write callback from the worker instance. When the worker wants to write
       // code the terminal, this event will be triggered.
       case 'write':
-        try {
-          // Only write when the worker is ready. This prevents infinite loops
-          // with print statements to continue printing after the worker has
-          // terminated when the user has pressed the stop button.
-          if (this.isReady) {
-            Terra.app.termWrite(event.data.data);
-          }
-        } catch (e) {
-          console.log("Caught write error on the terminal - clearing buffer;")
-          console.log(e)
-          Terra.app.termClearWriteBuffer();
+        // Only write when the worker is ready. This prevents infinite loops
+        // with print statements to continue printing after the worker has
+        // terminated when the user has pressed the stop button.
+        if (this.isReady) {
+          this.handlers.onWrite(event.data.data);
         }
         break;
 
       case 'write-error':
-        Terra.app.termWrite(`\x1b[1;31m${event.data.data}\x1b[0m`);
+        this.handlers.onWriteError(event.data.data);
         break;
 
       // Stdin callback from the worker instance. When the worker requests user
       // input, this event will be triggered. The user input will be requested
       // and sent back to the worker through the usage of shared memory.
       case 'readStdin':
-        Terra.app.termWaitForInput().then((value) => {
-          const view = new Uint8Array(this.sharedMem.buffer);
-          for (let i = 0; i < value.length; i++) {
-            // To the shared memory.
-            view[i] = value.charCodeAt(i);
-          }
-
-          // Set the last byte to the null terminator.
-          view[value.length] = 0;
-
-          Atomics.notify(new Int32Array(this.sharedMem.buffer), 0);
-        });
+        this.handlers.onRequestStdin().then((value) => this.provideStdin(value));
         break;
 
       // Run custom config button callback from the worker instance.
       // This event will be triggered after a custom config button's command has
       // been executed.
       case 'runButtonCommandCallback':
-        $('.lm_header .run-user-code-btn, .lm_header .config-btn').prop('disabled', false);
+        this.handlers.onRunButtonCommandDone();
         break;
 
       case 'restartWorker':
@@ -409,7 +348,8 @@ export default class LangWorker {
       case 'runUserCodeCallback':
         // Run user code callback invoked from the worker instance. This event
         // will be triggered after excecuting the user's code.
-        this.runUserCodeCallback();
+        this.isRunningCode = false;
+        this.handlers.onRunEnded();
         break;
 
       case 'newOrModifiedFilesCallback':
@@ -417,11 +357,11 @@ export default class LangWorker {
         // event will be triggered just before the run-user-code callback and
         // will only triggerer if there are new files created or existing files
         // have been modified during execution time.
-        this.newOrModifiedFilesCallback(event.data.newOrModifiedFiles);
+        this.handlers.onNewOrModifiedFiles(event.data.newOrModifiedFiles);
         break;
 
       case 'deletedFilesCallback':
-        this.deletedFilesCallback(event.data.deletedPaths);
+        this.handlers.onDeletedFiles(event.data.deletedPaths);
         break;
     }
   }

--- a/static/js/workers/lang-worker-client.js
+++ b/static/js/workers/lang-worker-client.js
@@ -64,7 +64,7 @@ export default class LangWorkerClient {
    *
    * @param {object} handlers - App-side reaction callbacks. Required keys:
    * onReady, onWrite, onWriteError, onRequestStdin, onRunButtonCommandDone,
-   * onRunEnded, onTerminate, onNewOrModifiedFiles, onDeletedFiles.
+   * onRunEnded, onNewOrModifiedFiles, onDeletedFiles.
    */
   constructor(handlers) {
     this.handlers = handlers;
@@ -133,13 +133,12 @@ export default class LangWorkerClient {
   }
 
   /**
-   * Terminate the existing worker process and delegate the terminal/UI cleanup
-   * (cursor, user input, terminate message) to the app.
-   *
-   * @param {boolean} [showTerminateMsg] - Print a message in the terminal
-   * indicating the current worker process has been terminated.
+   * Terminate the active worker process. Safe to call when idle. If a program
+   * was running when killed, the run-ended handler is invoked so the app can
+   * reset its UI and clean up the terminal; a clean post-run restart (where the
+   * run already reported completion) stays silent.
    */
-  terminate(showTerminateMsg) {
+  terminate() {
     // Safe to call when idle: nothing to tear down without an active worker.
     if (!this.worker) {
       return;
@@ -147,12 +146,18 @@ export default class LangWorkerClient {
 
     console.log(`Terminating existing ${this.proglang} worker`);
 
+    const wasRunning = this.isRunningCode;
     this.isRunningCode = false;
     this.isReady = false;
     this.worker.terminate();
     this.worker = null;
-    this.handlers.onRunEnded();
-    this.handlers.onTerminate(showTerminateMsg);
+
+    // Only when we abort a still-running program: a normal run already reported
+    // its end via the 'runUserCodeCallback' message, so the Pyodide post-run
+    // self-restart must not fire it again.
+    if (wasRunning) {
+      this.handlers.onRunEnded();
+    }
   }
 
   /**
@@ -237,15 +242,12 @@ export default class LangWorkerClient {
   }
 
   /**
-   * Terminate the code that is being run by the user. Useful when e.g. an
-   * infinite loop is detected. This process terminates the existing worker and
-   * create a complete new instance.
-   *
-   * @param {boolean} [showTerminateMsg] - Print a message in the terminal
-   * indicating the current worker process has been terminated.
+   * Tear down the existing worker and spawn a fresh instance for the same
+   * language. Used to abort a running program (e.g. an infinite loop) and for
+   * the Pyodide post-run reset.
    */
-  restart(showTerminateMsg) {
-    this.terminate(showTerminateMsg);
+  restart() {
+    this.terminate();
     this._createWorker();
   }
 
@@ -321,7 +323,7 @@ export default class LangWorkerClient {
         break;
 
       case 'restartWorker':
-        this.restart(false);
+        this.restart();
         break;
 
       case 'runUserCodeCallback':

--- a/static/js/workers/py.worker.js
+++ b/static/js/workers/py.worker.js
@@ -470,13 +470,18 @@ class API extends BaseAPI {
     globals.set('__name__', '__main__');
 
     try {
+      const rendered_code = code.join('\n')
+
       // Use matplotlib's Agg backend for static images.
-      this.pyodide.runPython("import matplotlib; matplotlib.use('Agg')");
+      if (rendered_code.includes("matplotlib")) {
+        console.log("Preloading matplotlib")
+        this.pyodide.runPython("import matplotlib; matplotlib.use('Agg')");
+      }
 
       // Most of the output will end up in the raw stdout handler defined
       // earlier, but some output will still end up in the console, which
       // generally happens solely for config buttons.
-      const result = this.pyodide.runPython(code.join('\n'), { globals, locals: globals });
+      const result = this.pyodide.runPython(rendered_code, { globals, locals: globals });
       if (result) {
         this.hostWrite(result);
       }


### PR DESCRIPTION
Clean up language worker interface class (client). Plus only preload matplotlib if used in Python program (saves huge amount of time).